### PR TITLE
Upgrade download link to 7.6 stable version

### DIFF
--- a/_pages/download.md
+++ b/_pages/download.md
@@ -6,7 +6,7 @@ title: Download
 
 # Quick Start
 
-The easiest way to set up Cuis in your system is the the latest [Cuis Stable Release](https://github.com/Cuis-Smalltalk/Cuis7-2).
+The easiest way to set up Cuis in your system is the the latest [Cuis Stable Release](https://github.com/Cuis-Smalltalk/Cuis7-6).
 
 
 


### PR DESCRIPTION
The site was offering version 7.2 as the stable version. I modified the download page link to propose version 7.6 as the default.